### PR TITLE
Fix wrong self type in extension method

### DIFF
--- a/subprojects/griffon-glazedlists-core-groovy/src/main/groovy/griffon/plugins/glazedlists/GlazedListsExtension.groovy
+++ b/subprojects/griffon-glazedlists-core-groovy/src/main/groovy/griffon/plugins/glazedlists/GlazedListsExtension.groovy
@@ -30,7 +30,7 @@ class GlazedListsExtension {
         withLockHandler(self.readWriteLock.readLock(), closure)
     }
 
-    static Object withWriteLock(Lock self, Closure closure) {
+    static Object withWriteLock(EventList self, Closure closure) {
         withLockHandler(self.readWriteLock.writeLock(), closure)
     }
 


### PR DESCRIPTION
GlazedListsExtension.withWriteLock seems to be an EventList extension in the same way as withReadLock.
